### PR TITLE
Include stdint.h

### DIFF
--- a/Sources/CZXingCpp/include/CZXingCpp.h
+++ b/Sources/CZXingCpp/include/CZXingCpp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cppstring.h"
+#include "stdint.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
#1 の修正。
macOS環境ではそのままビルドできていたのですが、Linux環境だと`stdint.h`のインクルードが必要でした。